### PR TITLE
FW-604: Add parameter "languagePath" as an option instead of "dialectID"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To execute the batch upload for words, for example, run the following command:
 
 You will be promoted for a password once you run the command.
 Parameters will differ depending on the Migrator being executed; memory allocation on the size of the import.
+The optional "-language-path" parameter will override the "-dialect-id" parameter by going to the path, getting the id from Nuxeo and using that instead.
 
 ## AbstractMigrator Parameters
 
@@ -67,6 +68,9 @@ Parameters will differ depending on the Migrator being executed; memory allocati
 
 -dialect-id = "The GUID of the dialect to input the entries into", required = true)
     protected static String dialectID;
+    
+-language-path = "The path to the language to input the entries into, rooted at /FV/Workspace/Data/")
+    protected static String languagePath;
 
 -csv-file = "Path to CSV file", required = true)
     protected static String csvFile;

--- a/src/main/java/task/AbstractMigrator.java
+++ b/src/main/java/task/AbstractMigrator.java
@@ -14,6 +14,7 @@ import org.nuxeo.client.NuxeoClient;
 import org.nuxeo.client.cache.ResultCacheInMemory;
 import org.nuxeo.client.objects.Document;
 import org.nuxeo.client.objects.Documents;
+import org.nuxeo.client.objects.Repository;
 import org.nuxeo.client.spi.NuxeoClientException;
 import reader.AbstractReader;
 import reader.CsvReader;
@@ -79,6 +80,9 @@ public abstract class AbstractMigrator {
 
     @Parameter(names = { "-dialect-id" }, description = "The GUID of the dialect to input the entries into", required = true)
     protected static String dialectID;
+    
+    @Parameter(names = { "-language-path" }, description = "The path to the language rooted at /FV/Workspaces/Data/")
+    protected static String languagePath;
 
     @Parameter(names = { "-csv-file" }, description = "Path to CSV file", required = true)
     protected static String csvFile;
@@ -208,7 +212,14 @@ public abstract class AbstractMigrator {
 
 	protected Map<String, Document> getOrCreateLanguageDocument(NuxeoClient client, String family, String lang, String dialect)
 			throws IOException {
-
+     
+	    // If path to language is given as a parameter then get the ID and set dialectID to that ID
+	    if ( languagePath != null ) {
+            Repository repository = client.repository();
+            Document folder = repository.fetchDocumentByPath("/FV/Workspaces/Data/" + languagePath);
+            dialectID = folder.getUid();
+        }
+	    
 		String cacheKey = dialectID;
 		String key = null;
 


### PR DESCRIPTION
If the optional parameter "-language-path" is given the program will go to that path (rooted at "/FV/Workspace/Data/"), get the ID and change the dialectID parameter to match it. An example parameter to enter for -language-path would be "-language-path TEst/Test/Dutch" to get the dialectID for the Dutch language in the test directory.