### PR TITLE
Fix index out of bounds exception when path and no ID parameters given

### DIFF
--- a/src/main/java/mappers/CsvValidator.java
+++ b/src/main/java/mappers/CsvValidator.java
@@ -5,6 +5,7 @@ import org.nuxeo.client.NuxeoClient;
 import org.nuxeo.client.cache.ResultCacheInMemory;
 import org.nuxeo.client.objects.Document;
 import org.nuxeo.client.objects.Documents;
+import org.nuxeo.client.objects.Repository;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,7 +45,7 @@ public class CsvValidator{
     private static final Set<String> POS = new HashSet<>(Arrays.asList(POS_VALUES));
 
 
-    public CsvValidator(String nuxeoUrl, String nuxeoUser, String nuxeoPassword, String csvFile, String dialectID) throws IOException{
+    public CsvValidator(String nuxeoUrl, String nuxeoUser, String nuxeoPassword, String csvFile, String dialectID, String languagePath) throws IOException{
 
         if (csvFile != null && !csvFile.isEmpty()) {
             fileReader = new InputStreamReader(new FileInputStream(csvFile), "UTF-8");
@@ -62,7 +63,14 @@ public class CsvValidator{
         t_or_f.add("CHILD_FRIENDLY");
         t_or_f.add("_SHARED_WITH_OTHER_DIALECTS");
         t_or_f.add("_CHILD_FOCUSED");
-
+        
+        // If path to language is given as a parameter then get the ID and set dialectID to that ID
+        if ( languagePath != null ) {
+            Repository repository = client.repository();
+            Document folder = repository.fetchDocumentByPath("/FV/Workspaces/Data/" + languagePath);
+            dialectID = folder.getUid();
+        }
+        
         getData(dialectID);
     }
 

--- a/src/main/java/task/FVCharacterMigrator.java
+++ b/src/main/java/task/FVCharacterMigrator.java
@@ -59,7 +59,7 @@ public class FVCharacterMigrator extends AbstractMigrator {
             characterMigrator.setReader(reader);
         }
 
-        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID);
+        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID, languagePath);
         List<String> valid = csvVal.validate(blobDataPath, limit);
 
         if(valid.isEmpty())

--- a/src/main/java/task/FVPhraseMigrator.java
+++ b/src/main/java/task/FVPhraseMigrator.java
@@ -73,7 +73,7 @@ public class FVPhraseMigrator extends AbstractMigrator {
             phraseMigrator.setReader(reader);
         }
 
-        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID);
+        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID, languagePath);
         List<String> valid = csvVal.validate(blobDataPath, limit);
 
         if(valid.isEmpty() || skipValidation)

--- a/src/main/java/task/FVWordMigrator.java
+++ b/src/main/java/task/FVWordMigrator.java
@@ -67,7 +67,7 @@ public class FVWordMigrator extends AbstractMigrator {
             wordMigrator.setReader(reader);
         }
 
-        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID);
+        CsvValidator csvVal = new CsvValidator(url, username, password, csvFile, dialectID, languagePath);
         List<String> valid = csvVal.validate(blobDataPath, limit);
 
         if(valid.isEmpty() || skipValidation)


### PR DESCRIPTION
When a path is given as a parameter for a batch script and no dialectID parameter is given then batch finds the UID from the path.  The CSV validator used the dialectID parameter regardless of wether or not a path was supplied, causing the validator to give an index out of bounds error when no correct dialectID was found.

With this fix the CSV validator will use the same logic as the rest of batch and find the correct UID if a path parameter is supplied.