### PR TITLE
Fix_media_truefalse_properties

### DIFF
--- a/src/main/java/mappers/firstvoices/BinaryMapper.java
+++ b/src/main/java/mappers/firstvoices/BinaryMapper.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import mappers.propertyreaders.PropertyReader;
 import mappers.propertyreaders.StorePropertyReader;
+import mappers.propertyreaders.TrueFalsePropertyReader;
 import org.nuxeo.client.objects.Document;
 import org.nuxeo.client.objects.blob.FileBlob;
 import org.nuxeo.client.spi.NuxeoClientException;
@@ -35,11 +36,11 @@ public abstract class BinaryMapper extends DictionaryCachedMapper {
     //propertyReaders.add(new PropertyReader(Properties.MEDIA_STATUS, prefix + "_" + Columns
     // .STATUS));
     propertyReaders
-        .add(new PropertyReader(Properties.MEDIA_SHARED, prefix + "_" + Columns.SHARED));
+        .add(new TrueFalsePropertyReader(Properties.MEDIA_SHARED, prefix + "_" + Columns.SHARED));
     propertyReaders.add(new PropertyReader(Properties.MEDIA_ACKNOWLEDGEMENT,
         prefix + "_" + Columns.ACKNOWLEDGEMENT));
     propertyReaders
-        .add(new PropertyReader(Properties.CHILD_FOCUSED, prefix + "_" + Columns.CHILD_FOCUSED));
+        .add(new TrueFalsePropertyReader(Properties.CHILD_FOCUSED, prefix + "_" + Columns.CHILD_FOCUSED));
 
     subdocuments.add(new SourcesMapper(Properties.MEDIA_SOURCE, prefix + "_" + Columns.SOURCE));
     subdocuments
@@ -157,7 +158,7 @@ public abstract class BinaryMapper extends DictionaryCachedMapper {
       }
 
       if (doc.getDirtyProperties().get(Properties.CHILD_FOCUSED) == null) {
-        doc.setPropertyValue(Properties.CHILD_FOCUSED, false);
+        doc.setPropertyValue(Properties.CHILD_FOCUSED, true);
       }
 
       try {

--- a/src/main/java/mappers/firstvoices/BinaryMapper.java
+++ b/src/main/java/mappers/firstvoices/BinaryMapper.java
@@ -35,8 +35,8 @@ public abstract class BinaryMapper extends DictionaryCachedMapper {
     propertyReaders.add(new PropertyReader(Properties.DESCR, prefix + "_" + Columns.DESCR));
     //propertyReaders.add(new PropertyReader(Properties.MEDIA_STATUS, prefix + "_" + Columns
     // .STATUS));
-    propertyReaders
-        .add(new TrueFalsePropertyReader(Properties.MEDIA_SHARED, prefix + "_" + Columns.SHARED));
+//    propertyReaders
+//        .add(new PropertyReader(Properties.MEDIA_SHARED, prefix + "_" + Columns.SHARED)); // remove this property -- should not be configurable to true until we have a better data sharing plan
     propertyReaders.add(new PropertyReader(Properties.MEDIA_ACKNOWLEDGEMENT,
         prefix + "_" + Columns.ACKNOWLEDGEMENT));
     propertyReaders
@@ -153,9 +153,9 @@ public abstract class BinaryMapper extends DictionaryCachedMapper {
 
       // Set some defaults for binary documents if they are not defined
 
-      if (doc.getDirtyProperties().get(Properties.MEDIA_SHARED) == null) {
-        doc.setPropertyValue(Properties.MEDIA_SHARED, false);
-      }
+//      if (doc.getDirtyProperties().get(Properties.MEDIA_SHARED) == null) {
+//        doc.setPropertyValue(Properties.MEDIA_SHARED, false);
+//      }
 
       if (doc.getDirtyProperties().get(Properties.CHILD_FOCUSED) == null) {
         doc.setPropertyValue(Properties.CHILD_FOCUSED, true);


### PR DESCRIPTION
Media import columns raised errors when users submitted values -- changed to use t/f property readers, then removed the media shared property entirely (default to false) until we can adjust how this works on the site